### PR TITLE
Revert "Fixed: Expansion is triggering in a lot of cases when it shouldn't (#16)"

### DIFF
--- a/src/Api/VSCodeApi.ts
+++ b/src/Api/VSCodeApi.ts
@@ -153,19 +153,4 @@ export class VSCodeApi {
         return null;
     }
 
-    public ReadNextLineFromCurrent(): string {
-        const lineCount: number = this.GetLineCount();
-        const curLine: number = this.GetActiveLine();
-
-        for (let i: number = curLine; i < lineCount - 1; i++) {
-
-            // Skip empty line
-            const line: string = this.ReadLine(i + 1);
-            if (StringUtil.IsNullOrWhiteSpace(line)) continue;
-
-            return line;
-        }
-
-        return null;
-    }
 }

--- a/src/Domain/Lang/DocommentDomainCSharp.ts
+++ b/src/Domain/Lang/DocommentDomainCSharp.ts
@@ -36,16 +36,27 @@ export class DocommentDomainCSharp extends DocommentDomain {
         // NG: Line is NOT /// (NG: ////)
         const activeLine: string = this._vsCodeApi.ReadLineAtCurrent();
         if (activeLine == null) return false;
-        if (isSlashKey || this._isEnterKey) {
-            const isDocComment: boolean = SyntacticAnalysisCSharp.IsDocComment(activeLine);
+        if (isSlashKey) {
+            const isDocComment: boolean = SyntacticAnalysisCSharp.IsDocCommentStrict(activeLine);
             if (!isDocComment) return false;
 
-            const previousLine: string = this._vsCodeApi.ReadPreviousLineFromCurrent();
-            if (SyntacticAnalysisCSharp.IsDocComment(previousLine)) return false;
-
-            const nextLine: string = this._vsCodeApi.ReadNextLineFromCurrent();
-            if (SyntacticAnalysisCSharp.IsDocComment(nextLine)) return false;
+            // NG: '/' => Insert => Event => ' /// '
+            if (SyntacticAnalysisCSharp.IsDoubleDocComment(activeLine)) return false;
         }
+        if (this._isEnterKey) {
+            const isDocComment: boolean = SyntacticAnalysisCSharp.IsDocComment(activeLine);
+            if (!isDocComment) return false;
+        }
+
+        // NG: Position is NOT ///
+        // const position: number = this._vsCodeApi.GetActiveCharPosition();
+        // const positionDocComment: number = activeLine.lastIndexOf('///') + ((isEnterKey) ? 3 : 2);
+        // const isLastPosition: boolean = (position === positionDocComment);
+        // if (!isLastPosition) return false;
+
+        // NG: Previous line is XML document comment
+        // const previousLine: string = this._vsCodeApi.ReadPreviousLineFromCurrent();
+        // if (SyntacticAnalysisCSharp.IsDocComment(previousLine)) return false;
 
         // OK
         return true;
@@ -75,7 +86,7 @@ export class DocommentDomainCSharp extends DocommentDomain {
 
 
         /*-------------------------------------------------------------------------
-         *
+         * 
          *-----------------------------------------------------------------------*/
         const isInMethod = false; // fixme:
         if (isInMethod) return CodeType.None;

--- a/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
+++ b/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
@@ -17,8 +17,16 @@ export class SyntacticAnalysisCSharp {
         return (activeChar === '/');
     }
 
+    public static IsDocCommentStrict(activeLine: string): boolean {
+        return activeLine.match(/(?:[^/]\/{3}[ \t]*$)|(?:^\/{3}[^/])|(?:^\/{3}[ \t]*$)/) !== null; // fixme: to simple
+    }
+
     public static IsDocComment(activeLine: string): boolean {
-        return activeLine.match(/^\s*?\/{3}\s*$/) !== null;
+        return activeLine.match(/\/{3}/) !== null;
+    }
+
+    public static IsDoubleDocComment(activeLine: string): boolean {
+        return activeLine.match(/^[ \t]+\/{3} $/) !== null;
     }
 
     /*-------------------------------------------------------------------------
@@ -89,7 +97,7 @@ export class SyntacticAnalysisCSharp {
         let paramName: Array<string> = new Array<string>();
         params[1].split(',').forEach(param => {
             const hasOptionaParam: boolean = param.match(/\S+\s+\S+\s*=/) !== null;
-            const name: RegExpMatchArray = (hasOptionaParam)
+            const name: RegExpMatchArray = (hasOptionaParam) 
                                            ? param.match(/\S+\s+(\S+)\s*=.*/)
                                            : param.match(/(\S+)\s*$/);
             if (name !== null && name.length === 2) {

--- a/test/SyntacticAnalysis/SyntacticAnalysisCSharp.test.ts
+++ b/test/SyntacticAnalysis/SyntacticAnalysisCSharp.test.ts
@@ -208,24 +208,4 @@ suite('SyntacticAnalysis.SyntacticAnalysisCSharp.IsClass Tests', () => {
             assert.equal(actual[1], 'onComplete');
         });
 
-    test(`
-        Category: Black-box testing
-        Class   : SyntacticAnalysis.SyntacticAnalysisCSharp
-        Method  : IsDocComment
-    `, () => {
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment('///'), true, '///');
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment(' ///'), true, ' ///');
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment(' /// '), true, ' /// ');
-
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment('/// ///'), false, '/// ///');
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment(' /// ///'), false, ' /// ///');
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment('//////'), false, '//////');
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment(' //////'), false, ' //////');
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment(' /////'), false, ' /////');
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment(' /// //'), false, ' /// //');
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment(' //// ///'), false, ' //// ///');
-            assert.equal(SyntacticAnalysisCSharp.IsDocComment(' /// <bla>'), false, "' /// <bla>'");
-        });
-
-
 });


### PR DESCRIPTION
Reverts k--kato/vscode-docomment#17

```csharp
[Before]
        ///    <- Press ENTER key
        public async Task<string> GetInfoForTime(string location, double time) {

        /// <summary>
        /// 
        /// </summary>
        /// <param name="location"></param>
        /// <param name="time"></param>
        /// <returns></returns>
        public async Task<string> GetInfoForTime(string location, double time) {

[After]
        ///    <- Press ENTER key
        public async Task<string> GetInfoForTime(string location, double time) {

        /// <summary>
        /// 
        /// /// </summary>  <- /// 
        /// <param name="location"></param>
        /// <param name="time"></param>
        /// <returns></returns>
        public async Task<string> GetInfoForTime(string location, double time) {
```