### PR TITLE
fixed  #29 Wrapping lines in the middle of text inserts /// in the wr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.0.12 (January 21, 2017)
+
+* bug fix - Wrapping lines in the middle of text inserts /// in the wrong place. See [#29](https://github.com/k--kato/vscode-docomment/issues/29).
+
 ## 0.0.11 (January 11, 2017)
 
 * bug fix - Auto-generated /// on the new line inside &lt;summary&gt; tag. See [#25](https://github.com/k--kato/vscode-docomment/issues/25), [#26](https://github.com/k--kato/vscode-docomment/issues/26).

--- a/package.json
+++ b/package.json
@@ -45,15 +45,15 @@
     "dependencies": {
     },
     "devDependencies": {
-        "typescript": "^2.1.4",
+        "typescript": "^2.1.5",
         "vscode": "^1.0.3",
         "tslint": "^4.3.1",
         "istanbul": "^0.4.5",
         "coveralls": "^2.11.15",
         "mocha": "^3.2.0",
         "mocha-lcov-reporter": "^1.2.0",
-        "@types/node": "^6.0.58",
-        "@types/mocha": "^2.2.36"
+        "@types/node": "^7.0.0",
+        "@types/mocha": "^2.2.38"
     },
     "extensionDependencies": [
     ],

--- a/src/Utility/StringUtil.ts
+++ b/src/Utility/StringUtil.ts
@@ -49,7 +49,7 @@ export class StringUtil {
         if (insertSpaces) {
             return indent.split(' ').length;
         } else {
-            return indent.split('\t').length * tabSize;
+            return indent.split('\t').length;
         }
     }
 

--- a/test/TestData/.vscode/settings.json
+++ b/test/TestData/.vscode/settings.json
@@ -3,9 +3,9 @@
     // Press the Enter key to activate a command (Default: false)
     "docomment.activateOnEnter": false,
     // Insert spaces when pressing Tab.
-    "editor.insertSpaces": true,
+    "editor.insertSpaces": false,
     // The number of spaces a tab is equal to.
     "editor.tabSize": 4,
     // When opening a file, `editor.tabSize` and `editor.insertSpaces` will be detected based on the file contents.
-    "editor.detectIndentation": true
+    "editor.detectIndentation": false
 }


### PR DESCRIPTION
Fixed #29 

* Known issues
    * must `"editor.detectIndentation": true` turn it `false`, currently. See #26.