### PR TITLE
Fix some duping

### DIFF
--- a/src/Domain/Lang/DocommentDomainCSharp.ts
+++ b/src/Domain/Lang/DocommentDomainCSharp.ts
@@ -80,6 +80,13 @@ export class DocommentDomainCSharp extends DocommentDomain {
     /* @override */
     public GetCodeType(code: string): CodeType {
 
+        // If the previous line was a doc comment and we hit enter.
+        // Extend the doc comment without generating anything else,
+        // even if there's a method or something next line.
+        if (this._isEnterKey && SyntacticAnalysisCSharp.IsDocComment(this._vsCodeApi.ReadLineAtCurrent())) {
+            return CodeType.Comment;
+        }
+
         /* method */
         if (SyntacticAnalysisCSharp.IsMethod(code)) return CodeType.Method;
 
@@ -121,6 +128,7 @@ export class DocommentDomainCSharp extends DocommentDomain {
 
         let paramNameList: Array<string> = null;
         let hasReturn = false;
+
         switch (codeType) {
             case CodeType.Namespace:
                 break;

--- a/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
+++ b/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
@@ -17,8 +17,12 @@ export class SyntacticAnalysisCSharp {
         return (activeChar === '/');
     }
 
+    /**
+     * Tests whether a line contains ONLY a doc comment and nothing else except whitespace.
+     * @param activeLine The line to test.
+     */
     public static IsDocCommentStrict(activeLine: string): boolean {
-        return activeLine.match(/(?:[^/]\/{3}[ \t]*$)|(?:^\/{3}[^/])|(?:^\/{3}[ \t]*$)/) !== null; // FIXME:
+        return activeLine.match(/^[ \t]*\/{3}[ \t]*$/) !== null; // FIXME:
     }
 
     public static IsDocComment(activeLine: string): boolean {


### PR DESCRIPTION
Fixes some cases where the plugin is too trigger happy when using `/` inside comments and attempting to extend the end of a comment.