### PR TITLE
Fixes #49 and CRLF issues.

### DIFF
--- a/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
+++ b/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
@@ -10,7 +10,7 @@ export class SyntacticAnalysisCSharp {
      * Public Method: Comment Type
      *-----------------------------------------------------------------------*/
     public static IsEnterKey(activeChar: string, text: string): boolean {
-        return (activeChar === '') && text.startsWith('\n');
+        return (activeChar === '') && (text.startsWith('\n') || text.startsWith("\r\n"));
     }
 
     public static IsSlashKey(activeChar: string): boolean {

--- a/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
+++ b/src/SyntacticAnalysis/SyntacticAnalysisCSharp.ts
@@ -129,18 +129,33 @@ export class SyntacticAnalysisCSharp {
     }
 
     public static HasMethodReturn(code: string): boolean {
-        if (code === null) return false;
+        if (code === null) {
+            return false;
+        }
+
         {
             const returns: RegExpMatchArray = code.match(/([\w\S]+)\s+[\w\S]+\s*\(.*\)/);
             const isMatched = (returns !== null && returns.length === 2);
-            const isReserved = (returns[1].match(this.RESERVED_WORDS) !== null);
-            if (isMatched && !isReserved) return true;
+            if (isMatched)
+            {
+                const isReserved = (returns[1].match(this.RESERVED_WORDS) !== null);
+                if (!isReserved)
+                {
+                    return true;
+                }
+            }
         }
         {
             const returns: RegExpMatchArray = code.match(/([\w\S]+)\s+[\w\S]+\s+[\w\S]+\s*\(.*\)/);
             const isMatched = (returns !== null && returns.length === 2);
-            const isReserved = (returns[1].match(this.RESERVED_WORDS) !== null);
-            if (isMatched && !isReserved) return true;
+            if (isMatched)
+            {
+                const isReserved = (returns[1].match(this.RESERVED_WORDS) !== null);
+                if (!isReserved)
+                {
+                    return true;
+                }
+            }
         }
 
         return false;


### PR DESCRIPTION
Fixes #49, this wasn't actually my fault but due to #48 and when I figured it out it was a really easy fix.

Fixes `IsEnterKey` from failing when using CRLF.

Also fixes #40, Technically was fixed by #47 but since it didn't work on Windows I'll link it here.